### PR TITLE
Update apiusers.js

### DIFF
--- a/components-express/routes/api/v1/apiusers.js
+++ b/components-express/routes/api/v1/apiusers.js
@@ -84,13 +84,11 @@ router.put('/:id', function (req, res, next) {
             } else {
                 // update if found
                 db.replace(putObj)
-                    .then(response => {
-                        res.json(response)
-                    })
-
             }
 
-            res.json(response)
+        })
+        .then(response => {
+               res.json(response)
         })
         .catch(error => {
             res.status(500).json(error)


### PR DESCRIPTION
I was getting this error on the put.
"(node:36500) UnhandledPromiseRejectionWarning: Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client"

to resolve:
remove the res.json() from line 93
remove the .then() from line 87-89, and move to be between the first .then() and the .catch

current setup creates a promise chain within a promise chain which I think is causing the error.

I reworked a bit to make it a ternary which I think looks pretty slick and seems to work well 

 db.readOne(putObj)
      .then(response => {
          return response == null ? db.create(putObj) : db.replace(putObj)
      })
      .then(response => {
        res.json(response)
    })
      .catch(error => {
          res.status(500).json(error)
      })